### PR TITLE
Dev fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ clean:
 
 # lint check
 lint:
-	pylint serpapi
+	python3 -m pylint serpapi
 
 # test with Python 3
 test:
-	pytest --cov=serpapi --cov-report html tests/*.py
+	python3 -m pytest --cov=serpapi --cov-report html tests/*.py
 
 # install dependencies
 # 
@@ -58,12 +58,12 @@ oobt: build
 
 
 check: oobt
-	twine check ${dist}
+	python3 -m twine check ${dist}
 
 release: # check
-	twine upload ${dist}
+	python3 -m twine upload ${dist}
 
 # run example only 
 #  and display output (-s)
 example:
-	pytest -s "tests/test_example.py::TestExample::test_async"
+	python3 -m pytest -s "tests/test_example.py::TestExample::test_async"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # User guide
 [![SerpApi-Python](https://github.com/serpapi/serpapi-python/actions/workflows/ci.yml/badge.svg)](https://github.com/serpapi/serpapi-python/actions/workflows/ci.yml)
 
-[SerpApi]](https://serpapi.com) allows to scrape any search engine results. 
- It's easy, fast, easy, feature rich, cost effective, scalable and reliable.
+[SerpApi](https://serpapi.com) allows to scrape any search engine results.
+It's easy, fast, easy, feature rich, cost effective, scalable and reliable.
 
-This Python 3 library is meant to scrape and parse results from all major search engines available world wide including Google, Bing, Baidu, Yandex, Yahoo, Ebay, Home depot, Apple and more using [SerpApi]](https://serpapi.com).
+This Python 3 library is meant to scrape and parse results from all major search engines available world wide including Google, Bing, Baidu, Yandex, Yahoo, Ebay, Home depot, Apple and more using [SerpApi](https://serpapi.com).
 This is an open source project hosted under https://github.com/serpapi/serpapi-python.
 
-SerpApi.com provides a [script builder]](https://serpapi.com/demo) to get you started quickly.
+SerpApi.com provides a [script builder](https://serpapi.com/demo) to get you started quickly.
 
 ## Installation
 SerpApi can be installed with pip.
@@ -17,78 +17,73 @@ $ python -m pip install serpapi
 ```
 
 ## Quick start
-First things first, import the serpapi module:
+
+The following example runs a search for `"coffee"` using your secret API key which you can find at [SerpApi Dashboard](https://serpapi.com/manage-api-key) page. The `serpapi.search` object handles all of the details of connection pooling and thread safety so that you don't have to:
 
 ```python
 import serpapi
-```
-You'll need a client instance to make a search. This object handles all of the details of connection pooling and thread safety so that you don't have to:
 
-```python
-client = serpapi.Client()
-```
-To make a search using SerpApi.com:
+client = serpapi.Client(
+  api_key = "secret_api_key", # from serpapi.com
+)
 
-```python
-parameter = {
-  api_key: "secret_api_key", # from serpapi.com
-  engine: "google",     # search engine
-  q: "coffee",          # search topic
-  location: "Austin,TX" # location
+parameters = {
+  "q": "coffee",
 }
-results = searpapi.search(parameter)
-```
-Putting everything together.
-```python
-import serpapi
 
-parameter = {
-  api_key: "secret_api_key", # from serpapi.com
-  engine: "google",     # search engine
-  q: "coffee",          # search topic
-  location: "Austin,TX" # location
-}
-results = searpapi.search(parameter)
+results = client.search(parameters)
+
 print(results)
 ```
 
 ### Advanced settings
 SerpApi Client uses urllib3 under the hood.
-Optionally, rhe HTTP connection can be tuned:
-  - timeout : connection timeout by default 60s
-  - retries : attempt to reconnect if the connection failed by default: False. 
-   serpapi is reliable at 99.99% but your company network might not be as stable.
 
-  ```python
-parameter = {
-   retries: 5,
-   timeout: 4.0,
-   # extra user parameters
-}
+Optionally, the HTTP connection can be tuned:
+  - timeout : connection timeout by default 60s
+  - retries : attempt to reconnect if the connection failed by default: False. Documentation: https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry
+  - api_key : the secret user API available from http://serpapi.com/manage-api-key
+
+   SerpApi's SLA is 99.95% successful searches: https://serpapi.com/faq/general/do-you-provide-sla-guarantees
+
+```python
+client = serpapi.Client(
+  retries = 5, # or urllib3.util.Retry(connect=5, read=2)
+  timeout = 4.2,
+  api_key = "secret_api_key", # from serpapi.com
+)
 ```
 
-for more details: [URL LIB3 documentation]](https://urllib3.readthedocs.io/en/stable/user-guide.html)
+For more details: [`urllib3` documentation](https://urllib3.readthedocs.io/en/stable/user-guide.html)
 
 ## Basic example per search engines
-### Search Bing
+
+
+
+### Search Google Local Services
 ```python
 import serpapi
 import pprint
 import os
 
+  def test_search_google_local_services(self):
 client = serpapi.Client({
-'engine': 'bing',
-'api_key': os.getenv("API_KEY")
+    'api_key': os.getenv("API_KEY"),
+    'timeout': 61.1,
+    'retries': 2
 })
 data = client.search({
-'q': 'coffee', 
+    'engine': 'google_local_services',
+    'q': 'Electrician', 
+    'place_id': 'ChIJOwg_06VPwokRYv534QaPC8g', 
 })
 pp = pprint.PrettyPrinter(indent=2)
-pp.pprint(data['organic_results'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
+pp.pprint(data['local_ads'])
 ```
- test: tests/example_search_bing.py
-see: [https://serpapi.com/bing-search-api](https://serpapi.com/bing-search-api)
+test: tests/example_search_google_local_services.py
+<br>
+Documentation: https://serpapi.com/google-local-services-search-api
+
 
 ### Search Baidu
 ```python
@@ -97,78 +92,19 @@ import pprint
 import os
 
 client = serpapi.Client({
-'engine': 'baidu',
-'api_key': os.getenv("API_KEY")
-})
+    'engine': 'baidu',
+    'api_key': os.getenv("API_KEY")
+  })
 data = client.search({
-'q': 'coffee', 
+    'q': 'coffee', 
 })
 pp = pprint.PrettyPrinter(indent=2)
 pp.pprint(data['organic_results'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
 ```
- test: tests/example_search_baidu.py
-see: [https://serpapi.com/baidu-search-api](https://serpapi.com/baidu-search-api)
+test: tests/example_search_baidu.py
+<br>
+Documentation: https://serpapi.com/baidu-search-api
 
-### Search Yahoo
-```python
-import serpapi
-import pprint
-import os
-
-client = serpapi.Client({
-'engine': 'yahoo',
-'api_key': os.getenv("API_KEY")
-})
-data = client.search({
-'p': 'coffee', 
-})
-pp = pprint.PrettyPrinter(indent=2)
-pp.pprint(data['organic_results'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
-```
- test: tests/example_search_yahoo.py
-see: [https://serpapi.com/yahoo-search-api](https://serpapi.com/yahoo-search-api)
-
-### Search Youtube
-```python
-import serpapi
-import pprint
-import os
-
-client = serpapi.Client({
-'engine': 'youtube',
-'api_key': os.getenv("API_KEY")
-})
-data = client.search({
-'search_query': 'coffee', 
-})
-pp = pprint.PrettyPrinter(indent=2)
-pp.pprint(data['video_results'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
-```
- test: tests/example_search_youtube.py
-see: [https://serpapi.com/youtube-search-api](https://serpapi.com/youtube-search-api)
-
-### Search Walmart
-```python
-import serpapi
-import pprint
-import os
-
-client = serpapi.Client({
-'engine': 'walmart',
-'api_key': os.getenv("API_KEY")
-})
-data = client.search({
-'query': 'coffee', 
-})
-pp = pprint.PrettyPrinter(indent=2)
-pp.pprint(data['organic_results'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
-```
- test: tests/example_search_walmart.py
-see: [https://serpapi.com/walmart-search-api](https://serpapi.com/walmart-search-api)
 
 ### Search Ebay
 ```python
@@ -177,58 +113,19 @@ import pprint
 import os
 
 client = serpapi.Client({
-'engine': 'ebay',
-'api_key': os.getenv("API_KEY")
-})
+    'engine': 'ebay',
+    'api_key': os.getenv("API_KEY")
+  })
 data = client.search({
-'_nkw': 'coffee', 
+    '_nkw': 'coffee', 
 })
 pp = pprint.PrettyPrinter(indent=2)
 pp.pprint(data['organic_results'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
 ```
- test: tests/example_search_ebay.py
-see: [https://serpapi.com/ebay-search-api](https://serpapi.com/ebay-search-api)
+test: tests/example_search_ebay.py
+<br>
+Documentation: https://serpapi.com/ebay-search-api
 
-### Search Naver
-```python
-import serpapi
-import pprint
-import os
-
-client = serpapi.Client({
-'engine': 'naver',
-'api_key': os.getenv("API_KEY")
-})
-data = client.search({
-'query': 'coffee', 
-})
-pp = pprint.PrettyPrinter(indent=2)
-pp.pprint(data['ads_results'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
-```
- test: tests/example_search_naver.py
-see: [https://serpapi.com/naver-search-api](https://serpapi.com/naver-search-api)
-
-### Search Home Depot
-```python
-import serpapi
-import pprint
-import os
-
-client = serpapi.Client({
-'engine': 'home_depot',
-'api_key': os.getenv("API_KEY")
-})
-data = client.search({
-'q': 'table', 
-})
-pp = pprint.PrettyPrinter(indent=2)
-pp.pprint(data['products'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
-```
- test: tests/example_search_home_depot.py
-see: [https://serpapi.com/home-depot-search-api](https://serpapi.com/home-depot-search-api)
 
 ### Search Apple App Store
 ```python
@@ -237,99 +134,19 @@ import pprint
 import os
 
 client = serpapi.Client({
-'engine': 'apple_app_store',
-'api_key': os.getenv("API_KEY")
-})
+    'engine': 'apple_app_store',
+    'api_key': os.getenv("API_KEY")
+  })
 data = client.search({
-'term': 'coffee', 
+    'term': 'coffee', 
 })
 pp = pprint.PrettyPrinter(indent=2)
 pp.pprint(data['organic_results'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
 ```
- test: tests/example_search_apple_app_store.py
-see: [https://serpapi.com/apple-app-store](https://serpapi.com/apple-app-store)
+test: tests/example_search_apple_app_store.py
+<br>
+Documentation: https://serpapi.com/apple-app-store-search-api
 
-### Search Duckduckgo
-```python
-import serpapi
-import pprint
-import os
-
-client = serpapi.Client({
-'engine': 'duckduckgo',
-'api_key': os.getenv("API_KEY")
-})
-data = client.search({
-'q': 'coffee', 
-})
-pp = pprint.PrettyPrinter(indent=2)
-pp.pprint(data['organic_results'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
-```
- test: tests/example_search_duckduckgo.py
-see: [https://serpapi.com/duckduckgo-search-api](https://serpapi.com/duckduckgo-search-api)
-
-### Search Google Search
-```python
-import serpapi
-import pprint
-import os
-
-client = serpapi.Client({
-'engine': 'google',
-'api_key': os.getenv("API_KEY")
-})
-data = client.search({
-'q': 'coffee', 
-'engine': 'google', 
-})
-pp = pprint.PrettyPrinter(indent=2)
-pp.pprint(data['organic_results'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
-```
- test: tests/example_search_google_search.py
-see: [https://serpapi.com/search-api](https://serpapi.com/search-api)
-
-### Search Google Scholar
-```python
-import serpapi
-import pprint
-import os
-
-client = serpapi.Client({
-'engine': 'google_scholar',
-'api_key': os.getenv("API_KEY")
-})
-data = client.search({
-'q': 'coffee', 
-})
-pp = pprint.PrettyPrinter(indent=2)
-pp.pprint(data['organic_results'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
-```
- test: tests/example_search_google_scholar.py
-see: [https://serpapi.com/google-scholar-api](https://serpapi.com/google-scholar-api)
-
-### Search Google Autocomplete
-```python
-import serpapi
-import pprint
-import os
-
-client = serpapi.Client({
-'engine': 'google_autocomplete',
-'api_key': os.getenv("API_KEY")
-})
-data = client.search({
-'q': 'coffee', 
-})
-pp = pprint.PrettyPrinter(indent=2)
-pp.pprint(data['suggestions'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
-```
- test: tests/example_search_google_autocomplete.py
-see: [https://serpapi.com/google-autocomplete-api](https://serpapi.com/google-autocomplete-api)
 
 ### Search Google Product
 ```python
@@ -338,80 +155,20 @@ import pprint
 import os
 
 client = serpapi.Client({
-'engine': 'google_product',
-'api_key': os.getenv("API_KEY")
-})
+    'engine': 'google_product',
+    'api_key': os.getenv("API_KEY")
+  })
 data = client.search({
-'q': 'coffee', 
-'product_id': '4172129135583325756', 
+    'q': 'coffee', 
+    'product_id': '4172129135583325756', 
 })
 pp = pprint.PrettyPrinter(indent=2)
 pp.pprint(data['product_results'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
 ```
- test: tests/example_search_google_product.py
-see: [https://serpapi.com/google-product-api](https://serpapi.com/google-product-api)
+test: tests/example_search_google_product.py
+<br>
+Documentation: https://serpapi.com/google-product-search-api
 
-### Search Google Reverse Image
-```python
-import serpapi
-import pprint
-import os
-
-client = serpapi.Client({
-'engine': 'google_reverse_image',
-'api_key': os.getenv("API_KEY")
-})
-data = client.search({
-'image_url': 'https://i.imgur.com/5bGzZi7.jpg', 
-})
-pp = pprint.PrettyPrinter(indent=2)
-pp.pprint(data['image_sizes'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
-```
- test: tests/example_search_google_reverse_image.py
-see: [https://serpapi.com/google-reverse-image](https://serpapi.com/google-reverse-image)
-
-### Search Google Events
-```python
-import serpapi
-import pprint
-import os
-
-client = serpapi.Client({
-'engine': 'google_events',
-'api_key': os.getenv("API_KEY")
-})
-data = client.search({
-'q': 'coffee', 
-})
-pp = pprint.PrettyPrinter(indent=2)
-pp.pprint(data['events_results'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
-```
- test: tests/example_search_google_events.py
-see: [https://serpapi.com/google-events-api](https://serpapi.com/google-events-api)
-
-### Search Google Local Services
-```python
-import serpapi
-import pprint
-import os
-
-client = serpapi.Client({
-'engine': 'google_local_services',
-'api_key': os.getenv("API_KEY")
-})
-data = client.search({
-'q': 'Electrician', 
-'place_id': 'ChIJOwg_06VPwokRYv534QaPC8g', 
-})
-pp = pprint.PrettyPrinter(indent=2)
-pp.pprint(data['local_ads'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
-```
- test: tests/example_search_google_local_services.py
-see: [https://serpapi.com/google-local-services-api](https://serpapi.com/google-local-services-api)
 
 ### Search Google Maps
 ```python
@@ -420,62 +177,21 @@ import pprint
 import os
 
 client = serpapi.Client({
-'engine': 'google_maps',
-'api_key': os.getenv("API_KEY")
-})
+    'engine': 'google_maps',
+    'api_key': os.getenv("API_KEY")
+  })
 data = client.search({
-'q': 'pizza', 
-'ll': '@40.7455096,-74.0083012,15.1z', 
-'type': 'search', 
+    'q': 'pizza', 
+    'll': '@40.7455096,-74.0083012,15.1z', 
+    'type': 'search', 
 })
 pp = pprint.PrettyPrinter(indent=2)
 pp.pprint(data['local_results'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
 ```
- test: tests/example_search_google_maps.py
-see: [https://serpapi.com/google-maps-api](https://serpapi.com/google-maps-api)
+test: tests/example_search_google_maps.py
+<br>
+Documentation: https://serpapi.com/google-maps-search-api
 
-### Search Google Jobs
-```python
-import serpapi
-import pprint
-import os
-
-client = serpapi.Client({
-'engine': 'google_jobs',
-'api_key': os.getenv("API_KEY")
-})
-data = client.search({
-'q': 'coffee', 
-})
-pp = pprint.PrettyPrinter(indent=2)
-pp.pprint(data['jobs_results'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
-```
- test: tests/example_search_google_jobs.py
-see: [https://serpapi.com/google-jobs-api](https://serpapi.com/google-jobs-api)
-
-### Search Google Play
-```python
-import serpapi
-import pprint
-import os
-
-def test_search_google_play(self):
-client = serpapi.Client({
-'engine': 'google_play',
-'api_key': os.getenv("API_KEY")
-})
-data = client.search({
-'q': 'kite', 
-'store': 'apps', 
-})
-pp = pprint.PrettyPrinter(indent=2)
-pp.pprint(data['organic_results'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
-```
- test: tests/example_search_google_play.py
-see: [https://serpapi.com/google-play-api](https://serpapi.com/google-play-api)
 
 ### Search Google Images
 ```python
@@ -484,20 +200,317 @@ import pprint
 import os
 
 client = serpapi.Client({
-'engine': 'google',
-'api_key': os.getenv("API_KEY")
-})
+    'engine': 'google',
+    'api_key': os.getenv("API_KEY")
+  })
 data = client.search({
-'engine': 'google', 
-'tbm': 'isch', 
-'q': 'coffee', 
+    'engine': 'google', 
+    'tbm': 'isch', 
+    'q': 'coffee', 
 })
 pp = pprint.PrettyPrinter(indent=2)
 pp.pprint(data['images_results'])
-# os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
 ```
- test: tests/example_search_google_images.py
-see: [https://serpapi.com/images-results](https://serpapi.com/images-results)
+test: tests/example_search_google_images.py
+<br>
+Documentation: https://serpapi.com/google-images-search-api
+
+
+### Search Google Search
+```python
+import serpapi
+import pprint
+import os
+
+client = serpapi.Client({
+    'engine': 'google',
+    'api_key': os.getenv("API_KEY")
+  })
+data = client.search({
+    'q': 'coffee', 
+    'engine': 'google', 
+})
+pp = pprint.PrettyPrinter(indent=2)
+pp.pprint(data['organic_results'])
+```
+test: tests/example_search_google_search.py
+<br>
+Documentation: https://serpapi.com/google-search-search-api
+
+
+### Search Google Jobs
+```python
+import serpapi
+import pprint
+import os
+
+client = serpapi.Client({
+    'engine': 'google_jobs',
+    'api_key': os.getenv("API_KEY")
+  })
+data = client.search({
+    'q': 'coffee', 
+})
+pp = pprint.PrettyPrinter(indent=2)
+pp.pprint(data['jobs_results'])
+```
+test: tests/example_search_google_jobs.py
+<br>
+Documentation: https://serpapi.com/google-jobs-search-api
+
+
+### Search Naver
+```python
+import serpapi
+import pprint
+import os
+
+client = serpapi.Client({
+    'engine': 'naver',
+    'api_key': os.getenv("API_KEY")
+  })
+data = client.search({
+    'query': 'coffee', 
+})
+pp = pprint.PrettyPrinter(indent=2)
+pp.pprint(data['ads_results'])
+```
+test: tests/example_search_naver.py
+<br>
+Documentation: https://serpapi.com/naver-search-api
+
+
+### Search Google Scholar
+```python
+import serpapi
+import pprint
+import os
+
+client = serpapi.Client({
+    'engine': 'google_scholar',
+    'api_key': os.getenv("API_KEY")
+  })
+data = client.search({
+    'q': 'coffee', 
+})
+pp = pprint.PrettyPrinter(indent=2)
+pp.pprint(data['organic_results'])
+```
+test: tests/example_search_google_scholar.py
+<br>
+Documentation: https://serpapi.com/google-scholar-search-api
+
+
+### Search Youtube
+```python
+import serpapi
+import pprint
+import os
+
+client = serpapi.Client({
+    'engine': 'youtube',
+    'api_key': os.getenv("API_KEY")
+  })
+data = client.search({
+    'search_query': 'coffee', 
+})
+pp = pprint.PrettyPrinter(indent=2)
+pp.pprint(data['video_results'])
+```
+test: tests/example_search_youtube.py
+<br>
+Documentation: https://serpapi.com/youtube-search-api
+
+
+### Search Google Reverse Image
+```python
+import serpapi
+import pprint
+import os
+
+client = serpapi.Client({
+    'engine': 'google_reverse_image',
+    'api_key': os.getenv("API_KEY")
+  })
+data = client.search({
+    'image_url': 'https://i.imgur.com/5bGzZi7.jpg', 
+})
+pp = pprint.PrettyPrinter(indent=2)
+pp.pprint(data['image_sizes'])
+```
+test: tests/example_search_google_reverse_image.py
+<br>
+Documentation: https://serpapi.com/google-reverse-image-search-api
+
+
+### Search Yahoo
+```python
+import serpapi
+import pprint
+import os
+
+client = serpapi.Client({
+    'engine': 'yahoo',
+    'api_key': os.getenv("API_KEY")
+  })
+data = client.search({
+    'p': 'coffee', 
+})
+pp = pprint.PrettyPrinter(indent=2)
+pp.pprint(data['organic_results'])
+```
+test: tests/example_search_yahoo.py
+<br>
+Documentation: https://serpapi.com/yahoo-search-api
+
+
+### Search Duckduckgo
+```python
+import serpapi
+import pprint
+import os
+
+client = serpapi.Client({
+    'engine': 'duckduckgo',
+    'api_key': os.getenv("API_KEY")
+  })
+data = client.search({
+    'q': 'coffee', 
+})
+pp = pprint.PrettyPrinter(indent=2)
+pp.pprint(data['organic_results'])
+```
+test: tests/example_search_duckduckgo.py
+<br>
+Documentation: https://serpapi.com/duckduckgo-search-api
+
+
+### Search Bing
+```python
+import serpapi
+import pprint
+import os
+
+client = serpapi.Client({
+    'engine': 'bing',
+    'api_key': os.getenv("API_KEY")
+  })
+data = client.search({
+    'q': 'coffee', 
+})
+pp = pprint.PrettyPrinter(indent=2)
+pp.pprint(data['organic_results'])
+```
+test: tests/example_search_bing.py
+<br>
+Documentation: https://serpapi.com/bing-search-api
+
+
+### Search Google Autocomplete
+```python
+import serpapi
+import pprint
+import os
+
+client = serpapi.Client({
+    'engine': 'google_autocomplete',
+    'api_key': os.getenv("API_KEY")
+  })
+data = client.search({
+    'q': 'coffee', 
+})
+pp = pprint.PrettyPrinter(indent=2)
+pp.pprint(data['suggestions'])
+```
+test: tests/example_search_google_autocomplete.py
+<br>
+Documentation: https://serpapi.com/google-autocomplete-search-api
+
+
+### Search Home Depot
+```python
+import serpapi
+import pprint
+import os
+
+client = serpapi.Client({
+    'engine': 'home_depot',
+    'api_key': os.getenv("API_KEY")
+  })
+data = client.search({
+    'q': 'table', 
+})
+pp = pprint.PrettyPrinter(indent=2)
+pp.pprint(data['products'])
+```
+test: tests/example_search_home_depot.py
+<br>
+Documentation: https://serpapi.com/home-depot-search-api
+
+
+### Search Walmart
+```python
+import serpapi
+import pprint
+import os
+
+client = serpapi.Client({
+    'engine': 'walmart',
+    'api_key': os.getenv("API_KEY")
+  })
+data = client.search({
+    'query': 'coffee', 
+})
+pp = pprint.PrettyPrinter(indent=2)
+pp.pprint(data['organic_results'])
+```
+test: tests/example_search_walmart.py
+<br>
+Documentation: https://serpapi.com/walmart-search-api
+
+
+### Search Google Events
+```python
+import serpapi
+import pprint
+import os
+
+client = serpapi.Client({
+    'engine': 'google_events',
+    'api_key': os.getenv("API_KEY")
+  })
+data = client.search({
+    'q': 'coffee', 
+})
+pp = pprint.PrettyPrinter(indent=2)
+pp.pprint(data['events_results'])
+```
+test: tests/example_search_google_events.py
+<br>
+Documentation: https://serpapi.com/google-events-search-api
+
+
+### Search Google Play
+```python
+import serpapi
+import pprint
+import os
+
+  def test_search_google_play(self):
+client = serpapi.Client({
+    'engine': 'google_play',
+    'api_key': os.getenv("API_KEY")
+  })
+data = client.search({
+    'q': 'kite', 
+    'store': 'apps', 
+})
+pp = pprint.PrettyPrinter(indent=2)
+pp.pprint(data['organic_results'])
+```
+test: tests/example_search_google_play.py
+<br>
+Documentation: https://serpapi.com/google-play-search-api
 
 # Developer Guide
 ### Key goals

--- a/README.md.erb
+++ b/README.md.erb
@@ -1,22 +1,22 @@
 <%-
 def snippet(format, path, start, stop) 
  slice = File.new(path).readlines[start..stop]
- slice.reject! { |l| l =~ /self.assertIsNone\(/ }
- buf = slice.map { |l| l.gsub(/(^\s+)/, '')}.join
+ slice.reject! { |l| l.match?(/self.assertIsNone\(/) || l.match?(/# os\.getenv\("API_KEY"\)/) }
+ buf = slice.map { |l| l.gsub(/(^\s{4})/, '').gsub(/^\s*$/, '') }.join
  buf.gsub!('self.assertIsNotNone(', "pp = pprint.PrettyPrinter(indent=2)\npp.pprint(")
- %Q(```#{format}\nimport serpapi\nimport pprint\nimport os\n\n#{buf}```\n test: #{path})
+ %Q(```#{format}\nimport serpapi\nimport pprint\nimport os\n\n#{buf}```\ntest: #{path})
 end
 -%>
 # User guide
 [![SerpApi-Python](https://github.com/serpapi/serpapi-python/actions/workflows/ci.yml/badge.svg)](https://github.com/serpapi/serpapi-python/actions/workflows/ci.yml)
 
-[SerpApi]](https://serpapi.com) allows to scrape any search engine results. 
- It's easy, fast, easy, feature rich, cost effective, scalable and reliable.
+[SerpApi](https://serpapi.com) allows to scrape any search engine results.
+It's easy, fast, easy, feature rich, cost effective, scalable and reliable.
 
-This Python 3 library is meant to scrape and parse results from all major search engines available world wide including Google, Bing, Baidu, Yandex, Yahoo, Ebay, Home depot, Apple and more using [SerpApi]](https://serpapi.com).
+This Python 3 library is meant to scrape and parse results from all major search engines available world wide including Google, Bing, Baidu, Yandex, Yahoo, Ebay, Home depot, Apple and more using [SerpApi](https://serpapi.com).
 This is an open source project hosted under https://github.com/serpapi/serpapi-python.
 
-SerpApi.com provides a [script builder]](https://serpapi.com/demo) to get you started quickly.
+SerpApi.com provides a [script builder](https://serpapi.com/demo) to get you started quickly.
 
 ## Installation
 SerpApi can be installed with pip.
@@ -26,142 +26,55 @@ $ python -m pip install serpapi
 ```
 
 ## Quick start
-First things first, import the serpapi module:
+
+The following example runs a search for `"coffee"` using your secret API key which you can find at [SerpApi Dashboard](https://serpapi.com/manage-api-key) page. The `serpapi.search` object handles all of the details of connection pooling and thread safety so that you don't have to:
 
 ```python
 import serpapi
-```
-You'll need a client instance to make a search. This object handles all of the details of connection pooling and thread safety so that you don't have to:
 
-```python
-client = serpapi.Client()
-```
-To make a search using SerpApi.com:
+client = serpapi.Client(
+  api_key = "secret_api_key", # from serpapi.com
+)
 
-```python
-parameter = {
-  api_key: "secret_api_key", # from serpapi.com
-  engine: "google",     # search engine
-  q: "coffee",          # search topic
-  location: "Austin,TX" # location
+parameters = {
+  "q": "coffee",
 }
-results = searpapi.search(parameter)
-```
-Putting everything together.
-```python
-import serpapi
 
-parameter = {
-  api_key: "secret_api_key", # from serpapi.com
-  engine: "google",     # search engine
-  q: "coffee",          # search topic
-  location: "Austin,TX" # location
-}
-results = searpapi.search(parameter)
+results = client.search(parameters)
+
 print(results)
 ```
 
 ### Advanced settings
 SerpApi Client uses urllib3 under the hood.
-Optionally, rhe HTTP connection can be tuned:
-  - timeout : connection timeout by default 60s
-  - retries : attempt to reconnect if the connection failed by default: False. 
-   serpapi is reliable at 99.99% but your company network might not be as stable.
 
-  ```python
-parameter = {
-   retries: 5,
-   timeout: 4.0,
-   # extra user parameters
-}
+Optionally, the HTTP connection can be tuned:
+  - timeout : connection timeout by default 60s
+  - retries : attempt to reconnect if the connection failed by default: False. Documentation: https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry
+  - api_key : the secret user API available from http://serpapi.com/manage-api-key
+
+   SerpApi's SLA is 99.95% successful searches: https://serpapi.com/faq/general/do-you-provide-sla-guarantees
+
+```python
+client = serpapi.Client(
+  retries = 5, # or urllib3.util.Retry(connect=5, read=2)
+  timeout = 4.2,
+  api_key = "secret_api_key", # from serpapi.com
+)
 ```
 
-for more details: [URL LIB3 documentation]](https://urllib3.readthedocs.io/en/stable/user-guide.html)
+For more details: [`urllib3` documentation](https://urllib3.readthedocs.io/en/stable/user-guide.html)
 
 ## Basic example per search engines
-### Search Bing
-<%= snippet('python', 'tests/example_search_bing.py', 9, 25) %>
-see: [https://serpapi.com/bing-search-api](https://serpapi.com/bing-search-api)
 
-### Search Baidu
-<%= snippet('python', 'tests/example_search_baidu.py', 9, 25) %>
-see: [https://serpapi.com/baidu-search-api](https://serpapi.com/baidu-search-api)
+<%- Dir.glob('tests/example_search_*.py').each do |example| -%>
+<% engine = example.match('example_search_(\w+)\.py')[1] %>
 
-### Search Yahoo
-<%= snippet('python', 'tests/example_search_yahoo.py', 9, 25) %>
-see: [https://serpapi.com/yahoo-search-api](https://serpapi.com/yahoo-search-api)
-
-### Search Youtube
-<%= snippet('python', 'tests/example_search_youtube.py', 9, 25) %>
-see: [https://serpapi.com/youtube-search-api](https://serpapi.com/youtube-search-api)
-
-### Search Walmart
-<%= snippet('python', 'tests/example_search_walmart.py', 9, 25) %>
-see: [https://serpapi.com/walmart-search-api](https://serpapi.com/walmart-search-api)
-
-### Search Ebay
-<%= snippet('python', 'tests/example_search_ebay.py', 9, 25) %>
-see: [https://serpapi.com/ebay-search-api](https://serpapi.com/ebay-search-api)
-
-### Search Naver
-<%= snippet('python', 'tests/example_search_naver.py', 9, 25) %>
-see: [https://serpapi.com/naver-search-api](https://serpapi.com/naver-search-api)
-
-### Search Home Depot
-<%= snippet('python', 'tests/example_search_home_depot.py', 9, 25) %>
-see: [https://serpapi.com/home-depot-search-api](https://serpapi.com/home-depot-search-api)
-
-### Search Apple App Store
-<%= snippet('python', 'tests/example_search_apple_app_store.py', 9, 25) %>
-see: [https://serpapi.com/apple-app-store](https://serpapi.com/apple-app-store)
-
-### Search Duckduckgo
-<%= snippet('python', 'tests/example_search_duckduckgo.py', 9, 25) %>
-see: [https://serpapi.com/duckduckgo-search-api](https://serpapi.com/duckduckgo-search-api)
-
-### Search Google Search
-<%= snippet('python', 'tests/example_search_google_search.py', 9, 25) %>
-see: [https://serpapi.com/search-api](https://serpapi.com/search-api)
-
-### Search Google Scholar
-<%= snippet('python', 'tests/example_search_google_scholar.py', 9, 25) %>
-see: [https://serpapi.com/google-scholar-api](https://serpapi.com/google-scholar-api)
-
-### Search Google Autocomplete
-<%= snippet('python', 'tests/example_search_google_autocomplete.py', 9, 25) %>
-see: [https://serpapi.com/google-autocomplete-api](https://serpapi.com/google-autocomplete-api)
-
-### Search Google Product
-<%= snippet('python', 'tests/example_search_google_product.py', 9, 25) %>
-see: [https://serpapi.com/google-product-api](https://serpapi.com/google-product-api)
-
-### Search Google Reverse Image
-<%= snippet('python', 'tests/example_search_google_reverse_image.py', 9, 25) %>
-see: [https://serpapi.com/google-reverse-image](https://serpapi.com/google-reverse-image)
-
-### Search Google Events
-<%= snippet('python', 'tests/example_search_google_events.py', 9, 25) %>
-see: [https://serpapi.com/google-events-api](https://serpapi.com/google-events-api)
-
-### Search Google Local Services
-<%= snippet('python', 'tests/example_search_google_local_services.py', 9, 25) %>
-see: [https://serpapi.com/google-local-services-api](https://serpapi.com/google-local-services-api)
-
-### Search Google Maps
-<%= snippet('python', 'tests/example_search_google_maps.py', 9, 25) %>
-see: [https://serpapi.com/google-maps-api](https://serpapi.com/google-maps-api)
-
-### Search Google Jobs
-<%= snippet('python', 'tests/example_search_google_jobs.py', 9, 25) %>
-see: [https://serpapi.com/google-jobs-api](https://serpapi.com/google-jobs-api)
-
-### Search Google Play
-<%= snippet('python', 'tests/example_search_google_play.py', 9, 25) %>
-see: [https://serpapi.com/google-play-api](https://serpapi.com/google-play-api)
-
-### Search Google Images
-<%= snippet('python', 'tests/example_search_google_images.py', 9, 25) %>
-see: [https://serpapi.com/images-results](https://serpapi.com/images-results)
+### Search <%= engine.split('_').map(&:capitalize).join(' ') %>
+<%= snippet('python', "tests/example_search_#{engine}.py", 9, 40) %>
+<br>
+Documentation: https://serpapi.com/<%= engine.tr('_', '-') %>-search-api
+<%- end -%>
 
 # Developer Guide
 ### Key goals

--- a/tests/example_search_google_local_services.py
+++ b/tests/example_search_google_local_services.py
@@ -2,20 +2,23 @@
 import unittest
 import os
 import serpapi
+import urllib3
 
 class TestGoogleLocalServices(unittest.TestCase):
 
   @unittest.skipIf((os.getenv("API_KEY") == None), "no api_key provided")
   def test_search_google_local_services(self):
     client = serpapi.Client({
-        'engine': 'google_local_services',
-        'api_key': os.getenv("API_KEY")
-      })
+        'api_key': os.getenv("API_KEY"),
+        'timeout': 61.1,
+        'retries': 2
+    })
+
     data = client.search({
+        'engine': 'google_local_services',
         'q': 'Electrician', 
         'place_id': 'ChIJOwg_06VPwokRYv534QaPC8g', 
     })
     self.assertIsNone(data.get('error'))
     self.assertIsNotNone(data['local_ads'])
-    # os.getenv("API_KEY") captures the secret user API available from http://serpapi.com
-  
+    # os.getenv("API_KEY") captures the secret user API available from http://serpapi.com/manage-api-key


### PR DESCRIPTION
We with @dimitryzub reviewed #1 and applied some fixes:

* Paste documentation examples to `README.md` in a loop instead of duplicating the same lines for all of the engines.

* Changed signature of the `serpapi.Client` to accept three parameters instead of a dict. This mentally distinguishes arguments allowed to the client from the `Client#search()` method.

* Fixed `make all` execution by prepending `python -m` to Python commands.

This PR is WIP. We will copy examples from https://github.com/serpapi/google-search-results-python/pull/36 to this PR.