### PR TITLE
Clarify the `serpapi.Client` usage requirement for the `yield_pages` documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. serapi-python documentation master file, created by
+.. serpapi-python documentation master file, created by
    sphinx-quickstart on Sun Apr  3 21:09:40 2022.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
@@ -36,6 +36,11 @@ For example, the API endpoint ``https://serpapi.com/search.json`` is represented
    'https://en.wikipedia.org/wiki/Coffee'
 
 Any parameters that you pass to ``search()`` will be passed to the API. This includes the ``api_key`` parameter, which is required for all requests.
+
+.. _using-api-client-directly:
+
+Using the API Client directly
+^^^^^^^^^
 
 To make this less repetitive, and gain the benefit of connection pooling, let's start using the API Client directly::
 
@@ -116,9 +121,11 @@ You can get the next page of results::
    >>> type(s.next_page())
    <class 'serpapi.models.SerpResults'>
 
-Or iterate over all pages of results::
+To iterate over all pages of results, it's recommended to :ref:`use the API Client directly <using-api-client-directly>`::
 
-   >>> for page in s.yield_pages():
+   >>> client = serpapi.Client(api_key="secret_api_key")
+   >>> search = client.search(q="Coffee", engine="google", location="Austin, Texas", hl="en", gl="us")
+   >>> for page in search.yield_pages():
    ...     print(page["search_metadata"]["page_number"])
    1
    2


### PR DESCRIPTION
The `yield_pages` throws a 401 HTTP error without using the `serpapi.Client`. This happened because it's required to instantiate the `serpapi.Client` with the `api_key`.

Example: https://replit.com/@serpapi/GoogleSearchApi

:green_circle: Works

```python
params = { "q": "coffee" }
client = serpapi.Client(api_key=os.environ['SERPAPI_API_KEY'])
search = client.search(params)

for page in search.yield_pages():
  # ...
```

 :red_circle:  Didn't work (401 HTTP error)

```
serpapi.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://serpapi.com/search.json?device=desktop&engine=google&gl=se&google_domain=google.se&hl=sv&location=Sweden&num=100&q=b%C3%A4sta+espressomaskin&start=100
```

Code

```python
params = { "api_key": os.environ['SERPAPI_API_KEY'], "q": "coffee" }
search = serpapi.search(params)

for page in search.yield_pages():
  # ...
```