### PR TITLE
Removing double engine declaration for Google Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,6 @@ import serpapi
 client = serpapi.Client(api_key=os.getenv("API_KEY"))
 results = client.search({
     'engine': 'google_images',
-    'engine': 'google_images',
     'tbm': 'isch',
     'q': 'coffee',
 })


### PR DESCRIPTION
Fix the code sample that uses `engine` parameters twice in the `Google Image` part.