### PR TITLE
remove redundant 'engine' in google search

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,6 @@ client = serpapi.Client(api_key=os.getenv("API_KEY"))
 results = client.search({
     'engine': 'google',
     'q': 'coffee',
-    'engine': 'google',
 })
 ```
 - API Documentation: [serpapi.com/search-api](https://serpapi.com/search-api)


### PR DESCRIPTION
In the example code of using serpapi with google search, there is a redundant 'engine' word. 
Basically, I just remove it. It's so annoying xD